### PR TITLE
Corrected regexes to filter out comments and properly recognize keywords.

### DIFF
--- a/hdlparse/verilog_parser.py
+++ b/hdlparse/verilog_parser.py
@@ -10,27 +10,30 @@ from minilexer import MiniLexer
 
 verilog_tokens = {
   'root': [
-    (r'\bmodule\s+(\w+)\s*', 'module', 'module'),
+    (r'\bmodule\s*(\w+)\s*', 'module', 'module'),
     (r'/\*', 'block_comment', 'block_comment'),
     (r'//#+(.*)\n', 'metacomment'),
     (r'//.*\n', None),
   ],
   'module': [
-    (r'parameter\s*(signed|integer|realtime|real|time)?\s*(\[[^]]+\])?', 'parameter_start', 'parameters'),
-    (r'(input|inout|output)\s*(reg|supply0|supply1|tri|triand|trior|tri0|tri1|wire|wand|wor)?\s*(signed)?\s*(\[[^]]+\])?', 'module_port_start', 'module_port'),
+    (r'parameter\s+(?:(signed|integer|realtime|real|time)\s+)?(\[[^]]+\])?', 'parameter_start', 'parameters'),
+    (r'(input|inout|output)\s+(?:(reg|supply0|supply1|tri|triand|trior|tri0|tri1|wire|wand|wor)\s+)?(?:(signed)\s+)?(\[[^]]+\])?', 'module_port_start', 'module_port'),
     (r'endmodule', 'end_module', '#pop'),
     (r'/\*', 'block_comment', 'block_comment'),
     (r'//#\s*{{(.*)}}\n', 'section_meta'),
     (r'//.*\n', None),
   ],
   'parameters': [
-    (r'\s*parameter\s*(signed|integer|realtime|real|time)?\s*(\[[^]]+\])?', 'parameter_start'),
-    (r'\s*(\w+)[^),;]*', 'param_item'),
+    (r'\s*parameter\s+(?:(signed|integer|realtime|real|time)\s+)?(\[[^]]+\])?', 'parameter_start'),
+    (r'\s*(\w+)[^),;]+', 'param_item'),
     (r',', None),
     (r'[);]', None, '#pop'),
+    (r'/\*', 'block_comment', 'block_comment'),
+    (r'//#\s*{{(.*)}}\n', 'section_meta'),
+    (r'//.*\n', None),
   ],
   'module_port': [
-    (r'\s*(input|inout|output)\s*(reg|supply0|supply1|tri|triand|trior|tri0|tri1|wire|wand|wor)?\s*(signed)?\s*(\[[^]]+\])?', 'module_port_start'),
+    (r'\s*(input|inout|output)\s+(?:(reg|supply0|supply1|tri|triand|trior|tri0|tri1|wire|wand|wor)\s+)?(signed)?\s*(\[[^]]+\])?', 'module_port_start'),
     (r'\s*(\w+)\s*,?', 'port_param'),
     (r'[);]', None, '#pop'),
     (r'//#\s*{{(.*)}}\n', 'section_meta'),
@@ -69,7 +72,7 @@ class VerilogParameter(object):
     if self.default_value is not None:
       param = '{} := {}'.format(param, self.default_value)
     return param
-      
+
   def __repr__(self):
     return "VerilogParameter('{}')".format(self.name)
 
@@ -89,7 +92,7 @@ class VerilogModule(VerilogObject):
 
 def parse_verilog_file(fname):
   '''Parse a named Verilog file
-  
+
   Args:
     fname (str): File to parse.
   Returns:
@@ -208,7 +211,7 @@ def parse_verilog(text):
 
 def is_verilog(fname):
   '''Identify file as Verilog by its extension
-  
+
   Args:
     fname (str): File name to check
   Returns:
@@ -265,7 +268,7 @@ class VerilogExtractor(object):
 
   def is_array(self, data_type):
     '''Check if a type is an array type
-    
+
     Args:
       data_type (str): Data type
     Returns:


### PR DESCRIPTION
Hi, 
I fixed some of your lexer regexes to properly parse parameters and not include comments in parsing. Below some before and after and Verilog code, based on which I generated the output.

Before:
![smart_udp_rx-smart_udp_rx](https://user-images.githubusercontent.com/8792915/86246621-9281c000-bbab-11ea-8d27-2cdf63b368dd.png)

After:
![smart_udp_rx-smart_udp_rx](https://user-images.githubusercontent.com/8792915/86246773-d2e13e00-bbab-11ea-84ff-1ef67bf84df5.png)

And now the code, from which the test was generated.
```
module smart_udp_rx #(
  // Trigger bit width
  parameter TRIGGER_WIDTH = 16,
  // Trigger value which should cause the data to be written
  // or passed forward
  parameter TRIGGER_VALUE = 12666,
  // AXI bus width in bits.
  // The value shall be a multiple of 8 and be less than or equal
  // to REG_WIDTH.
  parameter AXI_WIDTH = 8,
  // Register (output data width)
  // This should be a multiple of 8 and more than or equal to AXI_WIDTH.
  // The data is saved LSB to MSB if the AXI_WIDTH is smaller than REG_WIDTH.
  // If non-registered mode is used, the data on the output will be aligned
  // to the LSB, so for a 32-bit register and 16-bit AXI_WIDTH, usable data
  // will be presented on bits [15:0].
  parameter REG_WIDTH = 32,
  // The number of AXI transaction at which the data should start
  // to be sampled
  parameter OFFSET = 0,
  // If 1, the output will be registered and be valid in between the incoming
  // packets, if 0 the data will be passed without any registering (purely
  // combinational)
  parameter REGISTERED = 1
)(
  //# {{clocks|}}
  input clk,
  input rst,

  //# {{trig|Triggering}}
  // Trigger signal - it can be a UDP port or any signal, in fact.
  input [TRIGGER_WIDTH-1:0] trigger_vector_in,
  // Trigger valid indicator. When 1, the trigger_vector_in is considered
  // valid. The trigger must remain valid at least until the end of the
  // transmission.
  input trigger_valid_in,

  //# {{axi|AXI Stream}}
  // AXI-Stream signals
  input [AXI_WIDTH-1:0] axi_data_in,
  input axi_data_valid_in,
  input axi_data_last_in,
  // This is and additional 'valid' signal. However, this shall stay asserted
  // (1) for the whole transmission period regardless of the valid signal,
  // which can indicate pauses in the transfer, this signal sets the boundaries
  // of the whole transaction.
  input axi_data_ready_in,

  //# {{out|Data output}}
  // Data output, registered or not depending on the parameters.
  output [REG_WIDTH-1:0] rx_data_out,
  // Indicates the data on rx_data_out are valid and ready to be read.
  // The state is kept until the data stops being valid.
  output rx_data_ready_out,
  // Indicates the data on rx_data_out are valid and ready to be read.
  // The state is kept for one clock cycle.
  output rx_data_ready_out_pulse
);

```